### PR TITLE
Changed the torch version to be greater than 2.0.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ pyzipper>=0.3.6
 regex>=2022.10.31
 requests>=2
 tokenizers==0.13.2
-torch==2.0.0
-torchvision==0.15.1
-torchaudio==2.0.1
+torch>2.0.0
+torchvision>=0.15.1
+torchaudio>=2.0.1
 tqdm==4.64.1
 transformers>=4.25.1
 typing_extensions==4.4.0


### PR DESCRIPTION
When running the transcriber there is a compatibility problem with torch and the CUDA drivers on H100 with the torch version 2.0.0. With the new requirements file it works on that machine. 