### PR TITLE
Added support for writing merged speakers for srt and vtt output formats

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = Transcriber
 description = Customised cli for AI transcription
-version = 1.3
+version = 1.4
 url = https://github.com/aau-claaudia/transcriber/
 auther = Nikolaj Andersen, Pelle Rosenbeck Gøeg, Speechbrain and OpenAI
 license_files = LICENSE

--- a/src/whispaau/cli_utils.py
+++ b/src/whispaau/cli_utils.py
@@ -138,10 +138,10 @@ def parse_arguments(args: Optional[list[Any]] = None) -> dict[str, Any]:
     )
 
     parser.add_argument(
-        "--group_speakers",
+        "--merge_speakers",
         action="store_true",
         default=False,
-        help="enables grouping of text with the same speaker",
+        help="enables merging of text entries with the same speaker",
     )
 
     parser.add_argument(

--- a/src/whispaau/utils.py
+++ b/src/whispaau/utils.py
@@ -2,13 +2,18 @@
 # -*- coding: utf-8 -*-
 
 """ """
+from _csv import Writer
+
 from . import writers
 
 from pathlib import Path
 from whisperx import utils
 from typing import TextIO
 
-WRITERS = {
+WRITERS = {}
+
+# this set of writers contains our own customized writers (csv, dote.json and docx)
+CUSTOMIZED_WRITERS = {
     name.strip("Write").lower(): cls
     for name, cls in writers.__dict__.items()
     if isinstance(cls, type) and name.startswith("Write")
@@ -18,13 +23,22 @@ OFFICIAL_WRITERS = {
     for name, cls in utils.__dict__.items()
     if isinstance(cls, type) and name.startswith("Write")
 }
+MERGED_SPEAKERS_WRITERS = {
+    name.strip("Write").lower(): cls
+    for name, cls in utils.__dict__.items()
+    if isinstance(cls, type) and (name.startswith("WriteSRT") or name.startswith("WriteVTT"))
+}
+# this set of writers contains our own customized writers and the official srt and vtt writers
+MERGED_SPEAKERS_WRITERS.update(CUSTOMIZED_WRITERS)
 
+# this set contains the customized and official writers
+WRITERS.update(CUSTOMIZED_WRITERS)
 WRITERS.update(OFFICIAL_WRITERS)
 
 
-def get_writer(output_format: str, output_dir: str | Path):
+def get_writer(output_format: str, output_dir: str | Path, writer_list):
     if output_format == "all":
-        all_writers = [writer(output_dir) for writer in WRITERS.values()]
+        all_writers = [writer(output_dir) for writer in writer_list.values()]
 
         def write_all(result: dict, file: TextIO, options: dict):
             for writer in all_writers:
@@ -32,4 +46,4 @@ def get_writer(output_format: str, output_dir: str | Path):
 
         return write_all
 
-    return WRITERS[output_format](output_dir)
+    return writer_list[output_format](output_dir)

--- a/tests/test_speaker_grouping.py
+++ b/tests/test_speaker_grouping.py
@@ -1,5 +1,5 @@
 import json
-from whispaau.writers import group_speakers
+from whispaau.writers import merge_speakers
 
 with open('resources/transcription_with_same_speaker.json') as json_file:
     data = json.load(json_file)
@@ -7,4 +7,4 @@ with open('resources/transcription_with_same_speaker.json') as json_file:
 with open('resources/expected_grouped_speakers.json') as json_file:
     expected_data = json.load(json_file)
 
-assert group_speakers(data) == expected_data
+assert merge_speakers(data) == expected_data


### PR DESCRIPTION
This change includes:

- support for writing merged speakers for csv, docx, dote.json, srt and vtt files
- if --merge_speakers is enabled then a set of separate files will be generated with merged speaker entries
- a bug fix for generating the zip-file: The application will no include everything from the output directory but only the relevant files



