### PR TITLE
Added default flag to indicate running transcriber from the GUI interface.

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,20 @@ def cli(args: dict[str, Any]) -> None:
             options,
             speaker_params
         )
-    files_to_pack = [path for path in output_dir.glob(f"*_{model_name}_*") if path.is_file()]
+    if args.get("transcriber_gui"):
+        # If running from the transcriber GUI the user can have multiple runs with different models
+        # Get all available model names
+        whisper_model_names = whisper.available_models()
+        # Include files for all model names
+        files_to_pack = [
+        path
+        for whisper_model_name in whisper_model_names
+        for path in output_dir.glob(f"*_{whisper_model_name}_*")
+        if path.is_file()
+        ]
+    else:
+        files_to_pack = [path for path in output_dir.glob(f"*_{model_name}_*") if path.is_file()]
+
     # Pack everything into a process_name.zip
     job_name_directory = Path(job_name)
     archiving(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = Transcriber
 description = Customised cli for AI transcription
-version = 1.8
+version = 1.9
 url = https://github.com/aau-claaudia/transcriber/
 auther = Nikolaj Andersen, Pelle Rosenbeck Gøeg, Speechbrain and OpenAI
 license_files = LICENSE

--- a/src/whispaau/cli_utils.py
+++ b/src/whispaau/cli_utils.py
@@ -145,6 +145,13 @@ def parse_arguments(args: Optional[list[Any]] = None) -> dict[str, Any]:
     )
 
     parser.add_argument(
+        "--transcriber_gui",
+        action="store_true",
+        default=False,
+        help="this flag indicates running from the transcriber GUI interface",
+    )
+
+    parser.add_argument(
         "--args", nargs=argparse.REMAINDER
     )  # added to catch empty requests through shell script
 


### PR DESCRIPTION
When running transcriber with this flag we include transcribed files for all models when creating the zip-file at the end. 
This is needed because the user may have multiple runs with different models when using the GUI, and we want to include all transcribed files in the zip-file. 